### PR TITLE
Calcul du score quand on utilise NT sur un feuille par test

### DIFF
--- a/layouts/partials/render/accessibility.html
+++ b/layouts/partials/render/accessibility.html
@@ -11,7 +11,6 @@
   {{ $.context.Scratch.Set (printf "%s%s" $scorekey "render-is-empty") 0 }}
   {{ $.context.Scratch.Set (printf "%s%s" $scorekey "totalTest")       0 }}
   {{ $.context.Scratch.Set (printf "%s%s" $scorekey "iCrit")           0 }}
-  {{ $.context.Scratch.Set (printf "%s%s" $scorekey "critCount")       slice }}
   {{ $.context.Scratch.Set (printf "%s%s" $scorekey "critere")         "" }}
 
   {{ $.context.Scratch.Delete $scorekey }}
@@ -28,7 +27,7 @@
       {{ $.context.Scratch.Set (printf "%s%s" $scorekey "critPageValue") slice }}
     {{ end }}
 
-    {{/* Range lines */}}
+    {{/* Range lines of the csv file */}}
     {{ range $id, $value2 := after $auditmethodology . }}
       {{ if or (eq (index (split . "|") 0) "c") (eq (index (split . "|") 0) "nc") }}
         {{ $.context.Scratch.Add (printf "%s%s" $scorekey "render-is-empty") 1 }}
@@ -41,10 +40,7 @@
         {{ $.context.Scratch.Add (printf "%s%s" $scorekey "totalTest") 1 }}
         {{ $.context.Scratch.Add (printf "%s%s" $scorekey "iCrit") 1 }}
       {{ end }}
-      {{ if ne ($.context.Scratch.Get (printf "%s%s" $scorekey "iCrit")) 0 }}
-        {{ $.context.Scratch.Add (printf "%s%s" $scorekey "critCount") (string $crit) }}
-      {{ end }}
-      {{ if and . (ne (index (split . "|") 0) "nt") }}
+      {{ if . }}
         {{ $.context.Scratch.Add (printf "%s%s" $scorekey "critPageValue") . }}
         {{ $.context.Scratch.Add (printf "%s%s" $scorekey "critPageValues") . }}
         {{/* Build array per pages */}}
@@ -63,6 +59,7 @@
     {{ $.context.Scratch.Set (printf "%s%s" $scorekey "critere") $crit }}
   {{ end }}
 
+  {{/* START */}}
   {{ range $key, $array := ($.context.Scratch.Get (printf "%s%s" $scorekey (printf "%s%s" $scorekey "critValues"))) }}
       {{ range $idx, $value := . }}
         {{ if eq (index (split $value "|") 0) "c" }}
@@ -79,6 +76,7 @@
         {{ end }}
       {{ end }}
   {{ end }}
+  {{/* END */}}
 
   {{ if and $auditfile ($.context.Scratch.Get (printf "%s%s" $scorekey "render-is-empty")) }}
     {{ $auditfile := after 1 .auditfile }}
@@ -97,6 +95,10 @@
           {{ $.context.Scratch.SetInMap (printf "%s%s" $scorekey "critNA") (string $id) . }}
         {{ end }}
 
+        {{ if eq (index (split (index $value 0) "|") 0) "nt" }}
+          {{ $.context.Scratch.SetInMap (printf "%s%s" $scorekey "critNT") (string $id) . }}
+        {{ end }}
+
         {{ if eq (index (split (index $value 0) "|") 0) "c"  }}
           {{ $.context.Scratch.SetInMap (printf "%s%s" $scorekey "critC") (string $id) . }}
         {{ end }}
@@ -107,10 +109,13 @@
 
       {{ else }}
         {{/* Set each test case if the array as multiple value values as "na" or "nt" (or "25" "50" "81") */}}
-
         {{/* START - Should be removed */}}
         {{ if ((and (eq (len (intersect $value (slice "na"))) 1) (eq (len (intersect $value (slice "25" "50" "81"))) 1))) }}
           {{ $.context.Scratch.SetInMap (printf "%s%s" $scorekey "critNA") (string $id) . }}
+        {{ end }}
+
+        {{ if ((and (eq (len (intersect $value (slice "nt"))) 1) (eq (len (intersect $value (slice "25" "50" "81"))) 1))) }}
+          {{ $.context.Scratch.SetInMap (printf "%s%s" $scorekey "critNT") (string $id) . }}
         {{ end }}
 
         {{ if ((and (eq (len (intersect $value (slice "c"))) 1) (eq (len (intersect $value (slice "25" "50" "81"))) 1))) }}
@@ -143,14 +148,18 @@
           {{ $rendercritererest := cond (eq (len ((intersect $rendercritererest (slice "81")))) 1) ($rendercritererest | symdiff (slice "81")) $rendercritererest }}
           {{ $rendercritererest := cond (eq (len ((intersect $rendercritererest (slice "?")))) 1) ($rendercritererest | symdiff (slice "?")) $rendercritererest }}
           {{ $rendercritererest := cond (gt (len $rendercritererest) 1) (cond (eq (len ((intersect $rendercritererest (slice "na")))) 1) ($rendercritererest | symdiff (slice "na")) $rendercritererest) $rendercritererest }}
-          {{ $rendercritererest := cond (gt (len $rendercritererest) 1) (cond (eq (len ((intersect $rendercritererest (slice "nt")))) 1) ($rendercritererest | symdiff (slice "nt")) $rendercritererest) $rendercritererest }}
+          {{/* $rendercritererest := cond (gt (len $rendercritererest) 1) (cond (eq (len ((intersect $rendercritererest (slice "nt")))) 1) ($rendercritererest | symdiff (slice "nt")) $rendercritererest) $rendercritererest */}}
 
           {{/* Fill Maps */}}
           {{ if and (eq (len $rendercritererest) 1) (eq (index $rendercritererest 0) "c") }}
             {{ $.context.Scratch.SetInMap (printf "%s%s" $scorekey "critC") (string $id) . }}
           {{ else if and (eq (len $rendercritererest) 1) (eq (index $rendercritererest 0) "na") }}
             {{ $.context.Scratch.SetInMap (printf "%s%s" $scorekey "critNA") (string $id) . }}
-          {{ else if in ($.context.Scratch.Get "value") "nc" }}
+          {{ else if and (eq (len $rendercritererest) 1) (eq (index $rendercritererest 0) "nt") }}
+            {{ $.context.Scratch.SetInMap (printf "%s%s" $scorekey "critNT") (string $id) . }}
+          {{ else if and (in $rendercritererest "nt") (not (in $rendercritererest "nc")) }}
+            {{ $.context.Scratch.SetInMap (printf "%s%s" $scorekey "critNT") (string $id) . }}
+          {{ else if in $rendercritererest "nc" }}
             {{ $.context.Scratch.SetInMap (printf "%s%s" $scorekey "critNC") (string $id) . }}
           {{ else }}
             {{ $.context.Scratch.SetInMap (printf "%s%s" $scorekey "critNC") (string $id) . }}
@@ -161,43 +170,41 @@
     {{ end }}
   {{ end }}
 
-  {{ $.context.Scratch.Set (printf "%s%s" $scorekey "critCount") (uniq ($.context.Scratch.Get (printf "%s%s" $scorekey "critCount"))) }}
+  {{ $critCount := (merge ($.context.Scratch.Get (printf "%s%s" $scorekey "critC")) ($.context.Scratch.Get (printf "%s%s" $scorekey "critNC")))  }}
 
   {{ $.context.Scratch.Set (printf "%s%s" $scorekey "iCritC") 0 }}
-
   {{ with ($.context.Scratch.Get (printf "%s%s" $scorekey "critC")) }}
     {{ $.context.Scratch.Set (printf "%s%s" $scorekey "iCritC") (len .) }}
   {{ end }}
 
   {{ $.context.Scratch.Set (printf "%s%s" $scorekey "iCritNA") 0 }}
-
   {{ with ($.context.Scratch.Get (printf "%s%s" $scorekey "critNA")) }}
     {{ $.context.Scratch.Set (printf "%s%s" $scorekey "iCritNA") (len .) }}
   {{ end }}
 
-  {{ $.context.Scratch.Set (printf "%s%s" $scorekey "iCritNC") 0 }}
+  {{ $.context.Scratch.Set (printf "%s%s" $scorekey "iCritNT") 0 }}
+  {{ with ($.context.Scratch.Get (printf "%s%s" $scorekey "critNT")) }}
+    {{ $.context.Scratch.Set (printf "%s%s" $scorekey "iCritNT") (len .) }}
+  {{ end }}
 
+  {{ $.context.Scratch.Set (printf "%s%s" $scorekey "iCritNC") 0 }}
   {{ with ($.context.Scratch.Get (printf "%s%s" $scorekey "critNC")) }}
     {{ $.context.Scratch.Set (printf "%s%s" $scorekey "iCritNC") (len .) }}
   {{ end }}
+
   {{ $.context.Scratch.Set (printf "%s%s" $scorekey "compliance") 0 }}
   {{ $.context.Scratch.Set (printf "%s%s" $scorekey "compliance")
-      (
-        (div (mul ($.context.Scratch.Get (printf "%s%s" $scorekey "iCritC")) 100)
-          (sub
-            (len ($.context.Scratch.Get (printf "%s%s" $scorekey "critCount")))
-            (($.context.Scratch.Get (printf "%s%s" $scorekey "iCritNA")))
-          )
-        )
-      ) }}
+      (div (mul ($.context.Scratch.Get (printf "%s%s" $scorekey "iCritC")) 100) (len $critCount) )
+  }}
   {{ if ($.context.Scratch.Get "critNC") }}{{ $.context.Scratch.Set (printf "%s%s" $scorekey "compliance") ((div (mul (($.context.Scratch.Get (printf "%s%s" $scorekey "iCritC"))) 100) (len ($.context.Scratch.Get (printf "%s%s" $scorekey "critNC"))))) }}{{ end }}
 
-  {{ $.context.Scratch.Set "total"                                 (cond (not ($.context.Scratch.Get (printf "%s%s" $scorekey "critCount"))) 0 (len ($.context.Scratch.Get (printf "%s%s" $scorekey "critCount")))) }}
+  {{ $.context.Scratch.Set "total"                                 (cond (not $critCount) 0 (add (len $critCount) (len ($.context.Scratch.Get (printf "%s%s" $scorekey "critNA"))))) }}
   {{ $.context.Scratch.SetInMap $scorekey "testtotal"              ($.context.Scratch.Get (printf "%s%s" $scorekey "totalTest")) }}
-  {{ $.context.Scratch.SetInMap $scorekey "total"                  ($.context.Scratch.Get (printf "%s%s" $scorekey "critCount")) }}
-  {{ $.context.Scratch.SetInMap $scorekey "conforme"               ($.context.Scratch.Get (printf "%s%s" $scorekey "critC")) }}
-  {{ $.context.Scratch.SetInMap $scorekey "nonconforme"            ($.context.Scratch.Get (printf "%s%s" $scorekey "critNC")) }}
-  {{ $.context.Scratch.SetInMap $scorekey "nonapplicable"          ($.context.Scratch.Get (printf "%s%s" $scorekey "critNA")) }}
+  {{ $.context.Scratch.SetInMap $scorekey "total"                  $critCount }}
+  {{ $.context.Scratch.SetInMap $scorekey "conforme"               (cond (not ($.context.Scratch.Get (printf "%s%s" $scorekey "critC"))) slice ($.context.Scratch.Get (printf "%s%s" $scorekey "critC"))) }}
+  {{ $.context.Scratch.SetInMap $scorekey "nonconforme"            (cond (not ($.context.Scratch.Get (printf "%s%s" $scorekey "critNC"))) slice ($.context.Scratch.Get (printf "%s%s" $scorekey "critNC"))) }}
+  {{ $.context.Scratch.SetInMap $scorekey "nonapplicable"          (cond (not ($.context.Scratch.Get (printf "%s%s" $scorekey "critNA"))) slice ($.context.Scratch.Get (printf "%s%s" $scorekey "critNA"))) }}
+  {{ $.context.Scratch.SetInMap $scorekey "nonteste"               (cond (not ($.context.Scratch.Get (printf "%s%s" $scorekey "critNT"))) slice ($.context.Scratch.Get (printf "%s%s" $scorekey "critNT"))) }}
   {{ $.context.Scratch.SetInMap $scorekey "conformepage"           ($.context.Scratch.Get (printf "%s%s" $scorekey "pageC")) }}
   {{ $.context.Scratch.SetInMap $scorekey "nonconformepage"        ($.context.Scratch.Get (printf "%s%s" $scorekey "pageNC")) }}
   {{/* $.context.Scratch.SetInMap $scorekey "value"                  ($.context.Scratch.Get (printf "%s%s" $scorekey (printf "%s%s" $scorekey "critValues"))) */}}
@@ -212,6 +219,7 @@
                             "conforme" ($.context.Scratch.Get (printf "%s%s" $scorekey "iCritC"))
                             "nonapplicable" ($.context.Scratch.Get (printf "%s%s" $scorekey "iCritNA"))
                             "nonconforme" ($.context.Scratch.Get (printf "%s%s" $scorekey "iCritNC"))
+                            "nonteste" ($.context.Scratch.Get (printf "%s%s" $scorekey "iCritNT"))
                       )
                       "compliance" (int ($.context.Scratch.Get (printf "%s%s" $scorekey "compliance")))
                     )

--- a/layouts/partials/templates/accessibility.html
+++ b/layouts/partials/templates/accessibility.html
@@ -88,11 +88,17 @@
     {{- end -}}
 
     <script>
+      console.group("Critères par type: ");
+      console.log("Critères C [{{ len ($.context.Scratch.Get "scores").criteria.conforme }}]:" , "{{ range $key, $value := ($.context.Scratch.Get "scores").criteria.conforme      }}{{ $key }}, {{ end }}")
+      console.log("Critères NC [{{ len ($.context.Scratch.Get "scores").criteria.nonconforme }}]:","{{ range $key, $value := ($.context.Scratch.Get "scores").criteria.nonconforme   }}{{ $key }}, {{ end }}")
+      console.log("Critères NA [{{ len ($.context.Scratch.Get "scores").criteria.nonapplicable }}]:","{{ range $key, $value := ($.context.Scratch.Get "scores").criteria.nonapplicable }}{{ $key }}, {{ end }}")
+      console.log("Critères NT [{{ len ($.context.Scratch.Get "scores").criteria.nonteste }}]:","{{ range $key, $value := ($.context.Scratch.Get "scores").criteria.nonteste }}{{ $key }}, {{ end }}")
+      console.groupEnd();
       console.group("Critères non testés: ");
-      console.log("Critères 25","{{ $.context.Scratch.Get "criterecontrol25"   }}")
-      console.log("Critères 50","{{ $.context.Scratch.Get "criterecontrol50"   }}")
-      console.log("Critères 81","{{ $.context.Scratch.Get "criterecontrol81"   }}")
-      console.log("Critères 106","{{ $.context.Scratch.Get "criterecontrol106" }}")
+      console.log("Critères 25 :", "{{ delimit ($.context.Scratch.Get "criterecontrol25") ", "   }}")
+      console.log("Critères 50 :", "{{ delimit ($.context.Scratch.Get "criterecontrol50") ", "   }}")
+      console.log("Critères 81 :", "{{ delimit ($.context.Scratch.Get "criterecontrol81") ", "   }}")
+      console.log("Critères 106 :","{{ delimit ($.context.Scratch.Get "criterecontrol106") ", "  }}")
       console.groupEnd();
     </script>
 

--- a/theme.toml
+++ b/theme.toml
@@ -5,7 +5,7 @@ description = "Tool for a French governemental Reports for Accessibility complia
 homepage = "https://github.com/disic/frago/"
 tags = ["audits", "accessibility", "compliance","RGAA","quality","front-end"]
 min_version = 0.8
-theme_version = "1.4"
+theme_version = "1.5.0"
 
 [author]
   name = "Bertrand Keller"


### PR DESCRIPTION
Le calcul des case remplies avec "nt" était considéré comme des case vides, donc test non effectué. 

Cela fonctionne très bien avec une feuille de contrôle uniquement par critère. Cela permet de faire des audits partiels. "nt" et une case vide "" sont équivalents. Cela évite de remplir NT partout. On laisse des cases vides pour dire que le test n'est pas fait.

Pour une feuille où on contrôle chacun des tests (ce que ne demande pas le RGAA et que beaucoup d'auditeurs ne font pas car trop lourd), la résultat est différent.

Désormais dasn le cas d'une feuille par test, si,
 * une cellule est vide, l'auditeur considère que le critère est : pas testé du tout car j'ai pas le temps ou ce n'est pas nécessaire, mais je veux quand même prendre en compte le critère dans le calcul
 * une cellule comporte "NT", l'auditeur considère que le critère est : pas testé, mais à faire sinon le critère n’est pas pris en compte

Dans ce cas, on a le critère 10. Dans lequel le test 3 n'est pas fait, donc le critère n'est pas pris en compte dans le calcul final ; car tous les tests ne sont pas fait.

```
10,1,1,c
10,1,2,c
10,1,3,nt
```

Pour certains critères, il faut faire tous les tests pour que le critère soit effectivement conforme ou pas. Alors que pour d'autres les tests sont conditionnels, donc cela ne se justifie pas.

Cette évolution répond donc à un besoin spécifique pour des auditeurs super experts qui veulent donner un état pour tous les tests. Seulement, son fonctionnement devient étrange car le terme "Non Testé" ne veut pas juste dire "Non Testé" dans le calcul ; il veut bien dire, je bloque le critère car je n'ai pas fini de tester ce critère complètement (ce qui veut aussi dire, je commence.à tester un critère mais je m'arrête au milieu).

Pour le moment c'est comme ça car sinon ça donne des calculs finaux peu rigoureux. Mais ça pose question sur l'usage d'une feuille par test.

