### PR TITLE
Link website web page project title is an url

### DIFF
--- a/layouts/accessibility/single.html
+++ b/layouts/accessibility/single.html
@@ -12,7 +12,7 @@
   {{- $projectTitle := (.GetPage "./").Title -}}{{ with $projectTitle }} pour {{ partialCached "utils/isURL.html" $projectTitle $projectTitle }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}
 {{- end -}}
 
-{{- define "main" -}}sss
+{{- define "main" -}}
   {{- $context := . -}}
   {{- partial "templates/accessibility.html" (dict "context" $context) -}}sss
 {{- end -}}

--- a/layouts/accessibility/single.html
+++ b/layouts/accessibility/single.html
@@ -7,12 +7,12 @@
       {{- end -}}
     {{- end -}}
   {{- else -}}
-    Audit Accessibilité
+    Audit Accessibilités
   {{- end -}}
-  {{- $projectTitle := (.GetPage "./").Title -}}{{ with $projectTitle }} pour {{ . }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}
+  {{- $projectTitle := (.GetPage "./").Title -}}{{ with $projectTitle }} pour {{ partialCached "utils/isURL.html" $projectTitle $projectTitle }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}
 {{- end -}}
 
-{{- define "main" -}}
+{{- define "main" -}}sss
   {{- $context := . -}}
-  {{- partial "templates/accessibility.html" (dict "context" $context) -}}
+  {{- partial "templates/accessibility.html" (dict "context" $context) -}}sss
 {{- end -}}

--- a/layouts/accessibility/single.html
+++ b/layouts/accessibility/single.html
@@ -7,7 +7,7 @@
       {{- end -}}
     {{- end -}}
   {{- else -}}
-    Audit Accessibilités
+    Audit Accessibilité
   {{- end -}}
   {{- $projectTitle := (.GetPage "./").Title -}}{{ with $projectTitle }} pour {{ partialCached "utils/isURL.html" $projectTitle $projectTitle }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}
 {{- end -}}

--- a/layouts/accessibility/single.html
+++ b/layouts/accessibility/single.html
@@ -1,4 +1,5 @@
 {{- define "title" -}}
+  {{- $context := . -}}
   {{- $alternate  := where (where .OutputFormats "Permalink" "eq" .Permalink) "Rel" "eq" "alternate" -}}
   {{- if ne (len $alternate) 0 -}}
     {{- with $alternate -}}
@@ -9,10 +10,10 @@
   {{- else -}}
     Audit Accessibilité
   {{- end -}}
-  {{- $projectTitle := (.GetPage "./").Title -}}{{ with $projectTitle }} pour {{ partialCached "utils/isURL.html" $projectTitle $projectTitle }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}
+  {{- $projectTitle := (.GetPage "./").Title -}}{{ with $projectTitle }} pour {{ partialCached "utils/isURL.html" (dict "context" $context "projectTitle" $projectTitle) $projectTitle }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}
 {{- end -}}
 
 {{- define "main" -}}
   {{- $context := . -}}
-  {{- partial "templates/accessibility.html" (dict "context" $context) -}}sss
+  {{- partial "templates/accessibility.html" (dict "context" $context) -}}
 {{- end -}}

--- a/layouts/audits/list.html
+++ b/layouts/audits/list.html
@@ -1,4 +1,5 @@
 {{- define "title" -}}
+  {{- $context := . -}}
   {{- $project      := partialCached "render/projectpath" . . -}}
   {{- $projectPath  := cond (fileExists (printf "audits/%s/index.md" ($project))) (printf "audits/%s/index.md" ($project)) (printf "audits/%s/_index.md" ($project)) -}}
   {{- $projectTitle := (.GetPage $projectPath).Title -}}
@@ -21,7 +22,7 @@
   {{- else -}}
         Synthèse
   {{- end -}}
-  {{ with $projectTitle }} pour {{ partialCached "utils/isURL.html" $projectTitle $projectTitle }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}
+  {{ with $projectTitle }} pour {{ partialCached "utils/isURL.html" (dict "context" $context "projectTitle" $projectTitle) $projectTitle }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}
 {{- end -}}
 
 {{- define "main" -}}

--- a/layouts/audits/list.html
+++ b/layouts/audits/list.html
@@ -21,7 +21,7 @@
   {{- else -}}
         Synthèse
   {{- end -}}
-  {{ with $projectTitle }} pour {{ . }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}
+  {{ with $projectTitle }} pour {{ partialCached "utils/isURL.html" $projectTitle $projectTitle }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}
 {{- end -}}
 
 {{- define "main" -}}

--- a/layouts/audits/single.html
+++ b/layouts/audits/single.html
@@ -12,7 +12,7 @@
         {{- else if eq .Format.BaseName "quality" -}}
           Audit Qualité
         {{- else if eq .Format.BaseName "performance" -}}
-          Audit Performancee
+          Audit Performance
         {{- else if eq .Format.BaseName "declaration" -}}
           Déclaration
         {{- end -}}
@@ -21,7 +21,7 @@
   {{- else -}}
         Synthèse
   {{- end -}}
-  {{ with $projectTitle }} pour {{ . }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}
+  {{ with $projectTitle }} pour {{ partialCached "utils/isURL.html" $projectTitle $projectTitle }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}
 {{- end -}}
 
 {{- define "main" -}}

--- a/layouts/audits/single.html
+++ b/layouts/audits/single.html
@@ -21,7 +21,7 @@
   {{- else -}}
         Synthèse
   {{- end -}}
-  {{ with $projectTitle }} pour {{ partialCached "utils/isURL.html" $projectTitle $projectTitle }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}
+  {{ with $projectTitle }} pour {{ partialCached "utils/isURL.html" (dict "context" $context "projectTitle" $projectTitle) $projectTitle }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}
 {{- end -}}
 
 {{- define "main" -}}

--- a/layouts/partials/templates/accessibility.html
+++ b/layouts/partials/templates/accessibility.html
@@ -59,7 +59,8 @@
   {{- $.context.Scratch.Set "glossaire" (printf "=\"%s%s/glossaire/#" ($context.Scratch.Get "guidelinename") ($context.Scratch.Get "guidelineversion")) -}}
 
   {{- if $project -}}<p>← <a href="{{ site.BaseURL | default "/" }}{{- with $project -}}{{ printf "audits/%s/" . }}{{- end -}}" class="link-more link-back" aria-label="Retour à la page {{ ($context.GetPage $project).Title }}">Retour à la page projet</a></p>{{- end -}}
-  <h1>Audit Accessibilité{{ with $projectTitle }}<small> pour {{ . }}</small>{{ end }}</h1>
+  <h1>Audit Accessibilité{{ with $projectTitle }}<small> pour {{ partialCached "utils/isURL.html" $projectTitle $projectTitle }}</small>{{ end }}</h1>
+
   {{/* START Display page content if exists */}}
   {{- if gt (len .context.Content) 10 -}}
   <div class="note">

--- a/layouts/partials/templates/accessibility.html
+++ b/layouts/partials/templates/accessibility.html
@@ -59,7 +59,7 @@
   {{- $.context.Scratch.Set "glossaire" (printf "=\"%s%s/glossaire/#" ($context.Scratch.Get "guidelinename") ($context.Scratch.Get "guidelineversion")) -}}
 
   {{- if $project -}}<p>← <a href="{{ site.BaseURL | default "/" }}{{- with $project -}}{{ printf "audits/%s/" . }}{{- end -}}" class="link-more link-back" aria-label="Retour à la page {{ ($context.GetPage $project).Title }}">Retour à la page projet</a></p>{{- end -}}
-  <h1>Audit Accessibilité{{ with $projectTitle }}<small> pour {{ partialCached "utils/isURL.html" $projectTitle $projectTitle }}</small>{{ end }}</h1>
+  <h1>Audit Accessibilité{{ with $projectTitle }}<small> pour {{ partialCached "utils/isURL.html" (dict "context" $context "projectTitle" $projectTitle) $projectTitle }}</small>{{ end }}</h1>
 
   {{/* START Display page content if exists */}}
   {{- if gt (len .context.Content) 10 -}}

--- a/layouts/partials/templates/performance.html
+++ b/layouts/partials/templates/performance.html
@@ -9,7 +9,7 @@
 
 <article class="wrapper narrow">
   {{- if $project -}}<p>← <a href="{{ site.BaseURL | default "/" }}{{- with $project -}}{{ printf "audits/%s/" . }}{{- end -}}" class="link-more link-back" aria-label="Retour à la page {{ ($context.GetPage $project).Title }}">Retour à la page projet</a></p>{{- end -}}
-  <h1>{{ with .Title }}{{ . }}{{ else }}Audit Performance{{ end }} {{ with $projectTitle }}<small> pour {{ . }}</small>{{ end }}</h1>
+  <h1>{{ with .Title }}{{ . }}{{ else }}Audit Performance{{ end }} {{ with $projectTitle }}<small> pour {{ partialCached "utils/isURL.html" $projectTitle $projectTitle }}</small>{{ end }}</h1>
   {{- partial "elements/content.html" .context.Content -}}
   {{/* Range performance file */}}
   {{- if ne ($.context.Scratch.Get "lastfile") "/false" -}}

--- a/layouts/partials/templates/performance.html
+++ b/layouts/partials/templates/performance.html
@@ -9,7 +9,7 @@
 
 <article class="wrapper narrow">
   {{- if $project -}}<p>← <a href="{{ site.BaseURL | default "/" }}{{- with $project -}}{{ printf "audits/%s/" . }}{{- end -}}" class="link-more link-back" aria-label="Retour à la page {{ ($context.GetPage $project).Title }}">Retour à la page projet</a></p>{{- end -}}
-  <h1>{{ with .Title }}{{ . }}{{ else }}Audit Performance{{ end }} {{ with $projectTitle }}<small> pour {{ partialCached "utils/isURL.html" $projectTitle $projectTitle }}</small>{{ end }}</h1>
+  <h1>{{ with .Title }}{{ . }}{{ else }}Audit Performance{{ end }} {{ with $projectTitle }}<small> pour {{ partialCached "utils/isURL.html" (dict "context" $context "projectTitle" $projectTitle) $projectTitle }}</small>{{ end }}</h1>
   {{- partial "elements/content.html" .context.Content -}}
   {{/* Range performance file */}}
   {{- if ne ($.context.Scratch.Get "lastfile") "/false" -}}

--- a/layouts/partials/templates/quality.html
+++ b/layouts/partials/templates/quality.html
@@ -25,7 +25,7 @@
 
 <article class="wrapper narrow audit">
 {{- if $project -}}<p>← <a href="{{ site.BaseURL | default "/" }}{{- with $project -}}{{ printf "audits/%s/" . }}{{- end -}}" class="link-more link-back" aria-label="Retour à la page {{ ($context.GetPage $project).Title }}">Retour à la page projet</a></p>{{- end -}}
-<h1>Audit Qualité {{ with $projectTitle }}<small> pour {{ . }}</small>{{ end }}</h1>
+<h1>Audit Qualité {{ with $projectTitle }}<small> pour {{ partialCached "utils/isURL.html" $projectTitle $projectTitle }}</small>{{ end }}</h1>
 {{- if gt (len .context.Content) 10 -}}
 <div class="note">
 {{- partial "elements/content.html" .context.Content -}}

--- a/layouts/partials/templates/quality.html
+++ b/layouts/partials/templates/quality.html
@@ -25,7 +25,7 @@
 
 <article class="wrapper narrow audit">
 {{- if $project -}}<p>← <a href="{{ site.BaseURL | default "/" }}{{- with $project -}}{{ printf "audits/%s/" . }}{{- end -}}" class="link-more link-back" aria-label="Retour à la page {{ ($context.GetPage $project).Title }}">Retour à la page projet</a></p>{{- end -}}
-<h1>Audit Qualité {{ with $projectTitle }}<small> pour {{ partialCached "utils/isURL.html" $projectTitle $projectTitle }}</small>{{ end }}</h1>
+<h1>Audit Qualité {{ with $projectTitle }}<small> pour {{ partialCached "utils/isURL.html" (dict "context" $context "projectTitle" $projectTitle) $projectTitle }}</small>{{ end }}</h1>
 {{- if gt (len .context.Content) 10 -}}
 <div class="note">
 {{- partial "elements/content.html" .context.Content -}}

--- a/layouts/partials/utils/isURL.html
+++ b/layouts/partials/utils/isURL.html
@@ -1,7 +1,17 @@
+{{ $context      := .context }}
+{{ $projectTitle := .projectTitle }}
+{{ $project      := partialCached "render/projectpath" $context $context }}
+
+{{ with (partialCached "render/context.html" (dict "context" $context "project" $project) $project) }}
+  {{ $context.Scratch.Set "website" (index (last 1 (sort .)) 0).website }}
+{{- end -}}
+
 {{ $matchurl     := "([\\w_-]+(?:(?:\\.[\\w_-]+)+))([\\w.,@?^=%&:\\/~+#-]*[\\w@?^=%&\\/~+#-])" }}
 {{ $matchhttp    := "(http|ftp|https)://" }}
 
-{{ $urlprefix := cond (gt (len (findRE $matchhttp .)) 0) "" "//" }}
-{{ $result    := cond (gt (len (findRE $matchurl .)) 0) (printf "<a href='%s%s'>%s</a>" $urlprefix . . | safeHTML) . }}
+{{ $urlprefix1 := cond (gt (len (findRE $matchhttp $projectTitle)) 0) "" "//" }}
+{{ $urlprefix2 := cond (gt (len (findRE $matchhttp ($context.Scratch.Get "website"))) 0) "" "//" }}
+{{ $result     := cond (gt (len (findRE $matchurl $projectTitle)) 0)                    (printf "<a href='%s%s'>%s</a>" $urlprefix1 $projectTitle $projectTitle | safeHTML) $projectTitle }}
+{{ $result     := cond (gt (len (findRE $matchurl ($context.Scratch.Get "website"))) 0) (printf "<a href='%s%s'>%s</a>" $urlprefix2 ($context.Scratch.Get "website") $projectTitle | safeHTML) $projectTitle }}
 
 {{ return $result }}

--- a/layouts/partials/utils/isURL.html
+++ b/layouts/partials/utils/isURL.html
@@ -1,0 +1,7 @@
+{{ $matchurl     := "([\\w_-]+(?:(?:\\.[\\w_-]+)+))([\\w.,@?^=%&:\\/~+#-]*[\\w@?^=%&\\/~+#-])" }}
+{{ $matchhttp    := "(http|ftp|https)://" }}
+
+{{ $urlprefix := cond (gt (len (findRE $matchhttp .)) 0) "" "//" }}
+{{ $result    := cond (gt (len (findRE $matchurl .)) 0) (printf "<a href='%s%s'>%s</a>" $urlprefix . . | safeHTML) . }}
+
+{{ return $result }}

--- a/layouts/performance/single.html
+++ b/layouts/performance/single.html
@@ -1,4 +1,4 @@
-{{- define "title" -}}{{- $projectTitle := (.GetPage "./").Title -}}Audit Performance {{ with $projectTitle }}pour {{ . }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}{{- end -}}
+{{- define "title" -}}{{- $projectTitle := (.GetPage "./").Title -}}Audit Performance {{ with $projectTitle }}pour {{ partialCached "utils/isURL.html" $projectTitle $projectTitle }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}{{- end -}}
 {{- define "main" -}}
 {{/* Vars */}}
 {{- $context := . -}}

--- a/layouts/performance/single.html
+++ b/layouts/performance/single.html
@@ -1,4 +1,7 @@
-{{- define "title" -}}{{- $projectTitle := (.GetPage "./").Title -}}Audit Performance {{ with $projectTitle }}pour {{ partialCached "utils/isURL.html" $projectTitle $projectTitle }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}{{- end -}}
+{{- define "title" -}}
+  {{- $context      := . -}}
+  {{- $projectTitle := (.GetPage "./").Title -}}Audit Performance {{ with $projectTitle }}pour {{ partialCached "utils/isURL.html" (dict "context" $context "projectTitle" $projectTitle) $projectTitle }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}
+{{- end -}}
 {{- define "main" -}}
 {{/* Vars */}}
 {{- $context := . -}}

--- a/layouts/quality/single.html
+++ b/layouts/quality/single.html
@@ -1,5 +1,8 @@
 
-{{- define "title" -}}{{- $projectTitle := (.GetPage "./").Title -}}Audit Qualité {{ with $projectTitle }}pour {{ partialCached "utils/isURL.html" $projectTitle $projectTitle }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}{{- end -}}
+{{- define "title" -}}
+  {{- $context      := . -}}
+  {{- $projectTitle := (.GetPage "./").Title -}}Audit Qualité {{ with $projectTitle }}pour {{ partialCached "utils/isURL.html" (dict "context" $context "projectTitle" $projectTitle) $projectTitle }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}
+{{- end -}}
 {{- define "main" -}}
 {{/* Vars */}}
 {{- $context := . -}}

--- a/layouts/quality/single.html
+++ b/layouts/quality/single.html
@@ -1,5 +1,5 @@
 
-{{- define "title" -}}{{- $projectTitle := (.GetPage "./").Title -}}Audit Qualité {{ with $projectTitle }}pour {{ . }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}{{- end -}}
+{{- define "title" -}}{{- $projectTitle := (.GetPage "./").Title -}}Audit Qualité {{ with $projectTitle }}pour {{ partialCached "utils/isURL.html" $projectTitle $projectTitle }}{{ else }}{{ (index (split (path.Dir .Path) "/") 1) }}{{ end }}{{- end -}}
 {{- define "main" -}}
 {{/* Vars */}}
 {{- $context := . -}}


### PR DESCRIPTION
Si le titre de la section est une url :

```
title: metiers.numerique.gouv.fr
```

On détecte que la chaine est une url. Et on crée un lien vers le site mentionné.
Ceci à pour effet dans les pages individuelles d'audit : accessibilité, performance et qualité.