### PR TITLE
Add compliance average

### DIFF
--- a/layouts/partials/components/quality/critical.html
+++ b/layouts/partials/components/quality/critical.html
@@ -22,14 +22,19 @@
 {{- with $.context.Scratch.Get "pagesstatus-critical" -}}
 <h3>Erreurs par criticité</h3>
 <table class="text-left">
-  <thead><tr><th>Intitulé</th><th class="text-center w-100">Page</th><th class="text-center w-100">Type</th><th class="text-center w-120">Criticité</th></tr></thead>
+  <thead>
+    <tr>
+      <th>Intitulé</th>
+      <th class="text-center w-100">Page</th>
+      <th class="text-center w-120">Criticité</th>
+    </tr>
+  </thead>
   <tbody>
   {{- range $key, $value := sort . "status" "asc" -}}
     <h3 hidden>{{ if $value }}{{ $key | humanize }}{{ end }}</h3>
       <tr>
         <td>#{{ add $key 1 }}{{ if .checked }} ✅ {{ else }} ❌ {{ end }}&nbsp;- <a href="{{ site.BaseURL | default "/" }}audits/{{ $project }}/quality#{{ .name | urlize }}">{{ .name }}</a></td>
         <td class="text-center">{{ if .pagename }}{{ .pagename }}{{ end }}</td>
-        <td class="text-center">{{ .type }}</td>
         <td class="critical{{ if eq .status "critique" }} bad{{ else if eq .status "important" }} medium{{ else if eq .status "moindre" }} normal{{ else }} none{{ end }}">
           <span class="emoticon">{{ if eq .status "critique" }}🚫 {{ else if eq .status "important" }}❗️ {{ else if eq .status "moindre" }}➰ {{ else }}❓ {{ end }}</span>
           <strong class="text-color-light">{{ .status }}{{ if not .status }}Aucune{{ end }}</strong>

--- a/layouts/partials/components/quality/lot.html
+++ b/layouts/partials/components/quality/lot.html
@@ -39,7 +39,6 @@
         <th>Intitulé</th>
         <th class="text-center w-100">Page</th>
         <th class="text-center w-100">Bloc</th>
-        <th class="text-center w-100">Type</th>
         <th class="text-center w-120">Critère</th>
       </tr>
     </thead>
@@ -55,7 +54,6 @@
           <td><a href="{{/* /audits/{{ $project }}/quality */}}#{{ .name | urlize }}">{{ .name | markdownify }}</a>{{ if .checked }} ✅{{ end }}<br>{{ .description | markdownify }}</td>
           <td class="text-center">{{ if .pagename }}{{ .pagename | markdownify }}{{ end }}</td>
           <td class="text-center" style="color: hsl(calc(220 + {{ mul ($.context.Scratch.Get "blockid") 143  }}), calc(90% + {{ mul ($.context.Scratch.Get "blockid") 1 }}%),40%);">{{ if .blockname }}<strong>{{ .blockname | replaceRE "-.*" "$1" }}</strong>{{ end }}</td>
-          <td class="text-center">{{ .type }}</td>
           <td class="text-center">
             <strong>
             {{- with .criterion -}}

--- a/layouts/partials/components/scores/accessibility-graph.html
+++ b/layouts/partials/components/scores/accessibility-graph.html
@@ -5,20 +5,24 @@
 {{- $.context.Scratch.Set "pageslistgraph" slice -}}
 {{- $topics := slice "Images" "Cadres" "Couleurs" "Multimedia" "Tableaux" "Liens" "Scripts" "Éléments obligatoires" "Structuration de l’information" "Présentation de l'information" "Formulaires" "Navigation" "Consultation" -}}
 {{- $auditmethodology := (len (intersect (index $auditfile 0) (slice "Thématiques" "Critères" "Tests"))) -}}
-{{ if eq $auditmethodology 2 }}
+
+{{/* Fill a slice with a list of audited pages */}}
+{{- if eq $auditmethodology 2 -}}
   {{- $.context.Scratch.Set "pageslistgraph" ((index $auditfile 0) | symdiff (slice "Thématiques" "Critères")) -}}
-{{ end }}
-{{ if eq $auditmethodology 3 }}
+{{- end -}}
+{{- if eq $auditmethodology 3 -}}
   {{- $.context.Scratch.Set "pageslistgraph" ((index $auditfile 0) | symdiff (slice "Thématiques" "Critères" "Tests")) -}}
-{{ end }}
+{{- end -}}
+
 {{/* By topics */}}
 {{- range $key, $value := $topics -}}
-{{- $.context.Scratch.Set "criterecounterconformetopic" 0 -}}
-{{- $.context.Scratch.Set "counterconformetopic" 0 -}}
-{{- $.context.Scratch.Set "counternonconformetopic" 0 -}}
-
+  {{- $.context.Scratch.Set "criterecounterconformetopic" 0 -}}
+  {{- $.context.Scratch.Set "counterconformetopic" 0 -}}
+  {{- $.context.Scratch.Set "counternonconformetopic" 0 -}}
+  {{/* Range lines */}}
   {{- range $id, $value := after 1 $auditfile -}}
   {{- if eq (index . 0) (string (add $key 1)) -}}
+    {{/* Range columns */}}
     {{- range after $auditmethodology . -}}
       {{- $.context.Scratch.SetInMap "conforme" (string $key) ($.context.Scratch.Get "counterconformetopic") -}}
       {{- $.context.Scratch.SetInMap "nonconforme" (string $key) ($.context.Scratch.Get "counternonconformetopic") -}}
@@ -29,30 +33,16 @@
   {{- end -}}
 {{- end -}}
 
-{{/* By pages */}}
-{{- range $key, $value := $.context.Scratch.Get "pageslistgraph" -}}
-{{- $.context.Scratch.Set "counterconformepage" 0 -}}
-{{- $.context.Scratch.Set "counternonconformepage" 0 -}}
-  {{- range after 1 $auditfile -}}
-    {{- range $id, $value := after $auditmethodology . -}}
-    {{- if eq $id $key -}}
-      {{- $.context.Scratch.SetInMap "conformepage" (string $key) ($.context.Scratch.Get "counterconformepage") -}}
-      {{- $.context.Scratch.SetInMap "nonconformepage" (string $key) ($.context.Scratch.Get "counternonconformepage") -}}
-      {{- if eq . "c" -}}{{ $.context.Scratch.Add "counterconformepage" 1 -}}{{ $.context.Scratch.SetInMap "conformepage" (string $key) ($.context.Scratch.Get "counterconformepage") }}{{- end -}}
-      {{- if and (ne . "na") (ne . "c") (ne . "?") (ne . "") (ne . "25") (ne . "50") (ne . "81") -}}{{ $.context.Scratch.Add "counternonconformepage" 1 -}}{{ $.context.Scratch.SetInMap "nonconformepage" (string $key) ($.context.Scratch.Get "counternonconformepage") }}{{- end -}}
-    {{- end -}}
-    {{- end -}}
-  {{- end -}}
-{{- end -}}
-
 {{- $counterconformesum := 0 -}}
 {{- $counternonapplicablesum := 0 -}}
 {{- $counternonconformesum := 0 -}}
+{{/* Range lines */}}
 {{- range $id, $value := after 1 $auditfile -}}
   {{- $.context.Scratch.Set "counterconformetopic" 0 -}}
   {{- $.context.Scratch.Set "counternonapplicable" 0 -}}
   {{- $.context.Scratch.Set "counternonconformetopic" 0 -}}
-  {{ range $id, $value := after $auditmethodology $value }}
+  {{/* Range columns */}}
+  {{- range $id, $value := after $auditmethodology $value -}}
     {{- if eq . "c" -}}{{- $.context.Scratch.Add "counterconformetopic" 1 -}}{{- end -}}
     {{- if eq . "na" -}}{{- $.context.Scratch.Add "counternonapplicable" 1 -}}{{- end -}}
     {{- if and (ne . "na") (ne . "c") (ne . "?") (ne . "") (ne . "25") (ne . "50") (ne . "81") -}}{{- $.context.Scratch.Add "counternonconformetopic" 1 -}}{{- end -}}
@@ -118,5 +108,4 @@
         ...options
     })
 </script>
-
 {{- end -}}

--- a/layouts/partials/render/accessibility.html
+++ b/layouts/partials/render/accessibility.html
@@ -27,7 +27,7 @@
       {{ $.context.Scratch.Set (printf "%s%s" $scorekey "critPageValue") slice }}
     {{ end }}
 
-    {{/* Range lines of the csv file */}}
+    {{/* Range columns of the csv file */}}
     {{ range $id, $value2 := after $auditmethodology . }}
       {{ if or (eq (index (split . "|") 0) "c") (eq (index (split . "|") 0) "nc") }}
         {{ $.context.Scratch.Add (printf "%s%s" $scorekey "render-is-empty") 1 }}
@@ -59,7 +59,7 @@
     {{ $.context.Scratch.Set (printf "%s%s" $scorekey "critere") $crit }}
   {{ end }}
 
-  {{/* START */}}
+  {{/* START :: value criteria for each page */}}
   {{ range $key, $array := ($.context.Scratch.Get (printf "%s%s" $scorekey (printf "%s%s" $scorekey "critValues"))) }}
       {{ range $idx, $value := . }}
         {{ if eq (index (split $value "|") 0) "c" }}
@@ -77,6 +77,17 @@
       {{ end }}
   {{ end }}
   {{/* END */}}
+
+  {{ $.context.Scratch.Set (printf "%s%s" $scorekey "Average") 0 }}
+  {{ $lengthPageC := len ($.context.Scratch.Get (printf "%s%s" $scorekey "pageC")) }}
+  {{ range $key, $array := ($.context.Scratch.Get (printf "%s%s" $scorekey "pageC")) }}
+      {{ $lengthC  := (len $array) }}
+      {{ $lengthNC := (len (index ($.context.Scratch.Get (printf "%s%s" $scorekey "pageNC")) $key)) }}
+      {{ $value    := float (sub 100 (div (mul (float $lengthNC) 100) (add $lengthC $lengthNC)) | lang.NumFmt 1)}}
+      {{ $.context.Scratch.SetInMap (printf "%s%s" $scorekey "pageAverage") (string $key) $value }}
+      {{ $.context.Scratch.Add (printf "%s%s" $scorekey "Average") (div $value $lengthPageC) }}
+  {{ end }}
+
 
   {{ if and $auditfile ($.context.Scratch.Get (printf "%s%s" $scorekey "render-is-empty")) }}
     {{ $auditfile := after 1 .auditfile }}
@@ -207,6 +218,7 @@
   {{ $.context.Scratch.SetInMap $scorekey "nonteste"               (cond (not ($.context.Scratch.Get (printf "%s%s" $scorekey "critNT"))) slice ($.context.Scratch.Get (printf "%s%s" $scorekey "critNT"))) }}
   {{ $.context.Scratch.SetInMap $scorekey "conformepage"           ($.context.Scratch.Get (printf "%s%s" $scorekey "pageC")) }}
   {{ $.context.Scratch.SetInMap $scorekey "nonconformepage"        ($.context.Scratch.Get (printf "%s%s" $scorekey "pageNC")) }}
+  {{ $.context.Scratch.SetInMap $scorekey "pageaverage"            ($.context.Scratch.Get (printf "%s%s" $scorekey "pageAverage")) }}
   {{/* $.context.Scratch.SetInMap $scorekey "value"                  ($.context.Scratch.Get (printf "%s%s" $scorekey (printf "%s%s" $scorekey "critValues"))) */}}
   {{ end }}
 
@@ -222,6 +234,7 @@
                             "nonteste" ($.context.Scratch.Get (printf "%s%s" $scorekey "iCritNT"))
                       )
                       "compliance" (int ($.context.Scratch.Get (printf "%s%s" $scorekey "compliance")))
+                      "complianceaverage" (int ($.context.Scratch.Get (printf "%s%s" $scorekey "Average")))
                     )
   ) }}
   {{/* warnf "%v" ($res | jsonify (dict "indent" "  ")) */}}

--- a/layouts/partials/render/externals.html
+++ b/layouts/partials/render/externals.html
@@ -25,6 +25,7 @@
           {{ $file         := (partialCached "render/accessibility" (dict "context" $context "project" $project "auditfile" .) $project .) }}
           {{ $auditcontext := index (partialCached "render/context.html" (dict "context" $context "project" $project) $project) (index $lastfile "auditfile-name") }}
           {{ $.context.Scratch.SetInMap "compliance"           (string (add $id 1)) $file.scores.compliance }}
+          {{ $.context.Scratch.SetInMap "complianceaverage"    (string (add $id 1)) $file.scores.complianceaverage }}
           {{ $.context.Scratch.SetInMap "project"              (string (add $id 1)) $project }}
           {{ $.context.Scratch.SetInMap "criteriatotals"       (string (add $id 1)) $file.scores.criteria.total }}
           {{ $.context.Scratch.Set      "compliancetotal"      (add (index ($.context.Scratch.Get "compliance") (string (add $id 1))) ($.context.Scratch.Get "compliancetotal")) }}
@@ -40,6 +41,7 @@
         {{ $.context.Scratch.SetInMap "name" (string (add $id 1000)) $name }}
           {{ range last 1 (sort .) }}
             {{ $.context.Scratch.SetInMap "compliance"           (string (add $id 1000)) .score.compliance }}
+            {{ $.context.Scratch.SetInMap "complianceaverage"    (string (add $id 1000)) .score.complianceaverage }}
             {{ $.context.Scratch.SetInMap "criteriatotals"       (string (add $id 1000)) .score.criteria.total }}
             {{ $.context.Scratch.Set      "compliancetotal"      (add (index ($.context.Scratch.Get "compliance") (string (add $id 1000))) ($.context.Scratch.Get "compliancetotal")) }}
             {{ $.context.Scratch.Set      "percentage"           (div ($.context.Scratch.Get "compliancetotal") (len ($.context.Scratch.Get "compliance"))) }}
@@ -53,11 +55,12 @@
 
 {{ return
     (dict
-      "names"      ($.context.Scratch.Get "name")
-      "compliance" ($.context.Scratch.Get "compliance")
-      "project"    ($.context.Scratch.Get "project")
-      "total"      ($.context.Scratch.Get "criteriatotals")
-      "context"    ($.context.Scratch.Get "context")
-      "percentage" (int ($.context.Scratch.Get "percentage"))
+      "names"             ($.context.Scratch.Get "name")
+      "compliance"        ($.context.Scratch.Get "compliance")
+      "complianceaverage" ($.context.Scratch.Get "complianceaverage")
+      "project"           ($.context.Scratch.Get "project")
+      "total"             ($.context.Scratch.Get "criteriatotals")
+      "context"           ($.context.Scratch.Get "context")
+      "percentage"        (int ($.context.Scratch.Get "percentage"))
     )
 }}

--- a/layouts/partials/templates/declaration.html
+++ b/layouts/partials/templates/declaration.html
@@ -76,15 +76,22 @@
   <ul>
     {{- with partialCached "render/externals" (dict "context" $context "project" $project "auditfile" ($.context.Scratch.Get "auditpath-csv")) $context $project ($.context.Scratch.Get "auditpath-csv") -}}
     {{- $map := . -}}
+    {{ $map }}
     {{- if ne (len .compliance) 1 -}}
       {{/* Cumulated scores */}}
       <li>{{ .percentage }}% {{ with ($.context.Scratch.Get "scores").scores.criteria.total }}des {{ . }} critères {{ end }}{{ with ($.context.Scratch.Get "context").audit.guidelines }}du {{ . }}{{ end }} sont respectés sur l’ensemble des parcours.</li>
-      {{ if ($.context.Scratch.Get "scores").criteria }}<li>{{ ($.context.Scratch.Get "scores").scores.compliance }}% {{ with ($.context.Scratch.Get "scores").scores.criteria.total }}des {{ . }} critères{{ end }} {{ with (index ($.context.Scratch.Get "scores") "criteretotal") }}testés {{ end }}{{ with ($.context.Scratch.Get "context").audit.guidelines }}du {{ . }}{{ end }} sont respectés {{ with ($.context.Scratch.Get "context").website }}pour {{ . }}{{ end }}.</li>{{ end }}
+      {{- if ($.context.Scratch.Get "scores").criteria -}}
+        <li>{{ ($.context.Scratch.Get "scores").scores.compliance }}% {{ with ($.context.Scratch.Get "scores").scores.criteria.total }}des {{ . }} critères{{ end }} {{ with (index ($.context.Scratch.Get "scores") "criteretotal") }}testés {{ end }}{{ with ($.context.Scratch.Get "context").audit.guidelines }}du {{ . }}{{ end }} sont respectés {{ with ($.context.Scratch.Get "context").website }}pour {{ . }}{{ end }} (le taux moyen est de {{ ($.context.Scratch.Get "scores").scores.complianceaverage }}%).</li>
+      {{- end -}}
         {{/* Specific score for sub services */}}
-        {{ range $id, $value :=.names }}<li>{{ index $map.compliance $id }}% des {{ index $map.total $id }} critères du {{ with (index $map.context $id).audit }}{{ .guidelines }}{{ end }} sont respectés pour {{ . }}</li>{{ end }}
+      {{- range $id, $value := .names }}
+        <li>
+          {{ index $map.compliance $id }}% des {{ index $map.total $id }} critères du {{ with (index $map.context $id).audit }}{{ .guidelines }}{{ end }} sont respectés pour {{ . }} (le taux moyen est de {{ index $map.complianceaverage $id }}%).
+        </li>
+      {{- end }}
       {{- else -}}
         {{/* If any sub services */}}
-        {{ if ($.context.Scratch.Get "scores").criteria }}<li>{{ ($.context.Scratch.Get "scores").scores.compliance }}% {{ with ($.context.Scratch.Get "scores").scores.criteria.total }}des {{ . }} critères testés{{ end }} {{ with (index ($.context.Scratch.Get "scores") "criteretotal") }}testés {{ end }}{{/* with ($.context.Scratch.Get "context").audit.guidelines }}du {{ . }}{{ end */}} sont respectés.</li>{{ end }}
+        {{ if ($.context.Scratch.Get "scores").criteria }}<li>{{ ($.context.Scratch.Get "scores").scores.compliance }}% {{ with ($.context.Scratch.Get "scores").scores.criteria.total }}des {{ . }} critères testés{{ end }} {{ with (index ($.context.Scratch.Get "scores") "criteretotal") }}testés {{ end }}{{/* with ($.context.Scratch.Get "context").audit.guidelines }}du {{ . }}{{ end */}} sont respectés (le taux moyen est de {{ ($.context.Scratch.Get "scores").scores.complianceaverage }}%).</li>{{ end }}
       {{- end -}}
     {{- end -}}
     {{/*- if ($.context.Scratch.Get "auditpath-csv") -}}<li>Accès à la grille d’audit RGAA : <a href="{{ $context.Site.BaseURL | default "/" }}{{ replace ($.context.Scratch.Get "auditpath-csv") "/content/" "" }}">Télécharger la grille d’audit RGAA{{ with .website }} pour {{ . }}{{ end }}</a>{{- end -*/}}


### PR DESCRIPTION
Calcul du taux moyen pour un audit.

Le taux moyen est la moyenne des taux de conformité par page. Il est généralement supérieur au taux réel. Il va permettre de diluer le score d'une page avec beaucoup de critères non conformes qui a elle seule va faire baisser le taux réel.

Il est donc indicatif.